### PR TITLE
Replace crosshair with circular pupil overlays

### DIFF
--- a/gaze_tracking/gaze_tracking.py
+++ b/gaze_tracking/gaze_tracking.py
@@ -104,9 +104,12 @@ class GazeTracking(object):
             color = (0, 255, 0)
             x_left, y_left = self.pupil_left_coords()
             x_right, y_right = self.pupil_right_coords()
-            cv2.line(frame, (x_left - 5, y_left), (x_left + 5, y_left), color)
-            cv2.line(frame, (x_left, y_left - 5), (x_left, y_left + 5), color)
-            cv2.line(frame, (x_right - 5, y_right), (x_right + 5, y_right), color)
-            cv2.line(frame, (x_right, y_right - 5), (x_right, y_right + 5), color)
+
+            # Draw circles around pupils using calculated radius
+            radius_left = self.eye_left.pupil.radius if self.eye_left.pupil.radius else 5
+            radius_right = self.eye_right.pupil.radius if self.eye_right.pupil.radius else 5
+
+            cv2.circle(frame, (x_left, y_left), radius_left, color, 2)
+            cv2.circle(frame, (x_right, y_right), radius_right, color, 2)
 
         return frame

--- a/gaze_tracking/pupil.py
+++ b/gaze_tracking/pupil.py
@@ -13,6 +13,7 @@ class Pupil(object):
         self.threshold = threshold
         self.x = None
         self.y = None
+        self.radius = None
 
         self.detect_iris(eye_frame)
 
@@ -50,5 +51,15 @@ class Pupil(object):
             moments = cv2.moments(contours[-2])
             self.x = int(moments['m10'] / moments['m00'])
             self.y = int(moments['m01'] / moments['m00'])
+
+            # Calculate radius by fitting an ellipse to the iris contour
+            if len(contours[-2]) >= 5:
+                ellipse = cv2.fitEllipse(contours[-2])
+                # Average the semi-major and semi-minor axes to get radius
+                self.radius = int((ellipse[1][0] + ellipse[1][1]) / 4)
+            else:
+                # Fallback: approximate radius from contour area
+                area = cv2.contourArea(contours[-2])
+                self.radius = int(np.sqrt(area / np.pi))
         except (IndexError, ZeroDivisionError):
             pass


### PR DESCRIPTION
### Summary
Fixed the visualization to display circular overlays around pupils instead of crosshairs.

### Changes
- Added radius calculation to Pupil class using ellipse fitting
- Replaced cv2.line() crosshairs with cv2.circle() overlays in annotated_frame()
- Circles dynamically match the detected pupil size
- Includes fallback to radius of 5 pixels if calculation fails

### Related Issue
Closes #10

Generated with [Claude Code](https://claude.ai/code)